### PR TITLE
fixed ValueError: max() arg is an empty sequence

### DIFF
--- a/lycheesyncer.py
+++ b/lycheesyncer.py
@@ -212,9 +212,10 @@ class LycheeSyncer:
 
     def updateAlbumsDate(self, albums):
 
-        for a in albums:
+        if len(a['photos']) > 0:
             maxdate = max(photo.sysdate for photo in a['photos'])
             self.dao.updateAlbumDate(a['id'], maxdate.replace(':', '-'))
+
 
     def deleteAllFiles(self):
         """


### PR DESCRIPTION
I get an error when trying to sync:

Traceback (most recent call last):
  File "/home/buster/lycheesync/main.py", line 85, in <module>
    main(conf_data)
  File "/home/buster/lycheesync/main.py", line 16, in main
    s.sync()
  File "/home/buster/lycheesync/lycheesyncer.py", line 317, in sync
    self.updateAlbumsDate(albums)
  File "/home/buster/lycheesync/lycheesyncer.py", line 216, in updateAlbumsDate
    maxdate = max(photo.sysdate for photo in a['photos'])
ValueError: max() arg is an empty sequence

That one seems to fix it (although i don't know if the function should set some date or not.. when it doesn't it seems to work fine though).
