### PR TITLE
Generate id for album creation ourselves

### DIFF
--- a/lycheesync/lycheedao.py
+++ b/lycheesync/lycheedao.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 import pymysql
 import datetime
+import time
 import re
 import logging
 from dateutil.parser import parse
@@ -282,9 +283,10 @@ class LycheeDAO:
         - album: the album properties list, at least the name should be specified
         Returns the created albumid or None
         """
-        album['id'] = None
+        album['id'] = ('%.4f'%time.time()).replace('.','')
 
-        query = ("insert into lychee_albums (title, sysstamp, public, password) values ('{}',{},'{}',NULL)".format(
+        query = ("insert into lychee_albums (id, title, sysstamp, public, password) values ({},'{}',{},'{}',NULL)".format(
+            album['id'],
             album['name'],
             datetime.datetime.now().strftime('%s'),
             str(self.conf["publicAlbum"]))
@@ -294,8 +296,8 @@ class LycheeDAO:
         try:
             cur = self.db.cursor()
             logger.debug("try to createAlbum: %s", query)
-            cur.execute("insert into lychee_albums (title, sysstamp, public, password) values (%s,%s,%s,NULL)", (album[
-                        'name'], datetime.datetime.now().strftime('%s'), str(self.conf["publicAlbum"])))
+            cur.execute("insert into lychee_albums (id, title, sysstamp, public, password) values (%s,%s,%s,%s,NULL)",
+                        (album['id'], album['name'], datetime.datetime.now().strftime('%s'), str(self.conf["publicAlbum"])))
             self.db.commit()
 
             cur.execute("select id from lychee_albums where title=%s", (album['name']))

--- a/ressources/lychee.sql
+++ b/ressources/lychee.sql
@@ -31,7 +31,7 @@ DROP TABLE IF EXISTS `lychee_albums`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `lychee_albums` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` bigint(14) NOT NULL,
   `title` varchar(100) NOT NULL DEFAULT '',
   `description` varchar(1000) DEFAULT '',
   `sysstamp` int(11) NOT NULL,
@@ -67,7 +67,7 @@ CREATE TABLE `lychee_log` (
   `line` int(11) NOT NULL,
   `text` text,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -99,7 +99,7 @@ CREATE TABLE `lychee_photos` (
   `size` varchar(20) NOT NULL,
   `iso` varchar(15) NOT NULL,
   `aperture` varchar(20) NOT NULL,
-  `make` varchar(50) DEFAULT NULL,
+  `make` varchar(50) NOT NULL,
   `model` varchar(50) NOT NULL,
   `shutter` varchar(30) NOT NULL,
   `focal` varchar(20) NOT NULL,


### PR DESCRIPTION
This is necessary, because Lychee is no longer using automatically generated ids for the album, see https://github.com/electerious/Lychee/commit/976635254e3eb8d2333e9e66760234ea24571b80

Fixes #55