### PR TITLE
Add missing comma to conf.json

### DIFF
--- a/ressources/conf.json
+++ b/ressources/conf.json
@@ -5,7 +5,7 @@
     "dbHost":"localhost",
     "dbSocket":"/var/run/mysqld/mysqld.sock",
     "thumbQuality":80,
-    "publicAlbum": 0
+    "publicAlbum": 0,
     "excludeAlbums": [
     ]
 }


### PR DESCRIPTION
A recent commit introduced a new "excludeAlbums" configuration but missed adding a comma (",") to the line before it (for the "publicAlbum" configuration).